### PR TITLE
Fix: assembleDebug fails on a fresh clone without keystore.properties

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -31,11 +31,13 @@ android {
     }
 
     signingConfigs {
-        create("release") {
-            storeFile = file(keystoreProperties.getProperty("storeFile", ""))
-            storePassword = keystoreProperties.getProperty("storePassword", "")
-            keyAlias = keystoreProperties.getProperty("keyAlias", "")
-            keyPassword = keystoreProperties.getProperty("keyPassword", "")
+        if (keystorePropertiesFile.exists()) {
+            create("release") {
+                storeFile = file(keystoreProperties.getProperty("storeFile", ""))
+                storePassword = keystoreProperties.getProperty("storePassword", "")
+                keyAlias = keystoreProperties.getProperty("keyAlias", "")
+                keyPassword = keystoreProperties.getProperty("keyPassword", "")
+            }
         }
     }
 
@@ -48,7 +50,9 @@ android {
         release {
             isMinifyEnabled = true
             isShrinkResources = true
-            signingConfig = signingConfigs.getByName("release")
+            if (keystorePropertiesFile.exists()) {
+                signingConfig = signingConfigs.getByName("release")
+            }
             proguardFiles(
                 getDefaultProguardFile("proguard-android-optimize.txt"),
                 "proguard-rules.pro"


### PR DESCRIPTION
## What's broken

`./gradlew assembleDebug` fails immediately on a fresh clone (no `keystore.properties`, which is gitignored — as documented in the README/CLAUDE.md):

```
* Where:
Build file '.../app/build.gradle.kts' line: 35
* What went wrong:
Cannot convert '' to File.
```

Cause: `signingConfigs { create("release") { storeFile = file(keystoreProperties.getProperty("storeFile", "")) ... } }` runs unconditionally. Gradle evaluates the whole `android {}` DSL at configuration time regardless of which task is requested, so even `assembleDebug` hits `file("")` and crashes.

## Fix

Guard both the `signingConfigs.create("release")` block and the `signingConfig = ...` assignment in `release {}` behind `keystorePropertiesFile.exists()`. Release builds still pick up signing exactly as before once `keystore.properties` exists; debug builds (and `assembleRelease` without a keystore, which just produces an unsigned APK) no longer crash.

## Verified

```
rm -f keystore.properties  # confirm it's absent
./gradlew clean assembleDebug   # BUILD SUCCESSFUL, 43 tasks executed
```

Ran into this while evaluating the project as a translation backend for another app — happy to adjust the approach if you'd prefer a different guard style (e.g. failing loudly with a clearer message instead of silently skipping signing).